### PR TITLE
Keep field-level validations persistant through tab changes

### DIFF
--- a/src/components/apply/Apply.js
+++ b/src/components/apply/Apply.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getFormValues, initialize } from 'redux-form';
+import { getFormValues, initialize, touch, blur } from 'redux-form';
 import _ from 'lodash';
 import { Tabs, Tab } from 'material-ui/Tabs';
 
@@ -14,7 +14,25 @@ const tabStyle = {
   fontWeight: 400,
 };
 
-const Apply = ({curValues, jointApplicantData, selectedApplicantId, jointApplicantCount, addJointApplicant, selectJointApplicant, initialize}) => {
+/**
+ * Helper function that initializes the form with the new values provided and executes the validators/normalizers
+ * for each untouched field as soon as its loaded, causing error messages to be displayed immediately.
+ */
+const initializeApplyForm = (formData, touchActionDispatcher, blurActionDispatcher) => {
+  // Actually insert the new values into the form
+  initialize('apply', formData, false);
+
+  // for each field that has values, simulate a `BLUR` event to trigger validators and normalizers
+  _.each(formData, (fieldValue, fieldName) => {
+    touchActionDispatcher('apply', fieldName);
+    blurActionDispatcher('apply', fieldName, fieldValue);
+  });
+};
+
+const Apply = ({
+  curValues, jointApplicantData, selectedApplicantId, jointApplicantCount,
+  addJointApplicant, selectJointApplicant, initialize, touch, blur
+}) => {
   const applicantTabs = _.map(_.range(jointApplicantCount), i => {
     return <Tab style={tabStyle} label={`Joint Applicant ${i + 1}`} key={i} value={i} />;
   });
@@ -35,7 +53,7 @@ const Apply = ({curValues, jointApplicantData, selectedApplicantId, jointApplica
     console.log('curValues: ', curValues);
 
     selectJointApplicant(index, curValues);
-    initialize('apply', jointApplicantData[index], false);
+    initializeApplyForm(jointApplicantData[index], touch, blur);
   };
 
   const removeAddOption = (tabs) => {
@@ -68,4 +86,4 @@ const mapStateToProps = state => ({
   curValues: applicantValuesSelector(state),
 });
 
-export default connect(mapStateToProps, {addJointApplicant, selectJointApplicant, initialize})(Apply);
+export default connect(mapStateToProps, {addJointApplicant, selectJointApplicant, initialize, touch, blur})(Apply);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -12,12 +12,17 @@ const blurType = blur().type;
 const focusType = focus().type;
 
 const applyFormReducer = (state, action={}) => {
-  if (action.type !== blurType && action.type !== focusType) {
+  switch(action.type) {
+  case focusType:
+  case blurType:
+    const fieldName = getIn(action, ['meta', 'field']);
+    return updateIn(state, ['values', fieldName], transformFieldEntry(fieldName, action.type));
+  case SELECT_APPLICANT:
+    break;
+  default:
     return state;
   }
 
-  const fieldName = getIn(action, ['meta', 'field']);
-  return updateIn(state, ['values', fieldName], transformFieldEntry(fieldName, action.type));
 };
 
 export default combineReducers({

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,9 +14,10 @@ const focusType = focus().type;
 const applyFormReducer = (state, action={}) => {
   switch(action.type) {
   case focusType:
-  case blurType:
+  case blurType: {
     const fieldName = getIn(action, ['meta', 'field']);
     return updateIn(state, ['values', fieldName], transformFieldEntry(fieldName, action.type));
+  }
   case SELECT_APPLICANT:
     break;
   default:


### PR DESCRIPTION
 * Invalid inputs on any field of a joint applicant form will remain tied to that form through multiple switches between tabs.
   * This is achieved by manually dispatching `TOUCH` and `BLUR` events for each of the changed fields whenever the form is initialized.