### PR TITLE
Fix application when redux-dev-tools not installed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,10 @@ injectTapEventPlugin(); //needed for material-ui
 
 const history = createHistory();
 const middleware = routerMiddleware(history);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const store = createStore(
   reducers,
-  compose(
-    applyMiddleware(middleware),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  )
+  composeEnhancers(applyMiddleware(...middleware))
 );
 
 // set up the Trabian dev tools


### PR DESCRIPTION
 * Use the advanced configuration since we're making use of `compose()`